### PR TITLE
Charakter Bild eingefuegt

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,3 +12,5 @@ Gordon Shumway vom Planeten Melmac landet mit seinem Raumschiff in der Garage de
 
 ALF sagt:
 > Null Problemo
+
+<img src="https://cdn.pixabay.com/photo/2016/07/14/17/26/alf-1517191_1280.jpg"/>


### PR DESCRIPTION
Es fehlte ein Bild des Charakters.
Dieses wurde verlinkt in der Datei index.md.
Fixes: #9 